### PR TITLE
Aligning the social network icon to the center

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -82,6 +82,7 @@ class Plugin extends PluginBase
                     'label'      => 'Social Logins',
                     'type'       => 'partial',
                     'path'       => '~/plugins/flynsarmy/sociallogin/models/provider/_provider_column.htm',
+                    'align'      => 'center',
                     'searchable' => false
                 ]
             ]);


### PR DESCRIPTION
Aligning the social network icon to the center in the list of users.

Documentation: https://wintercms.com/docs/backend/lists#column-options